### PR TITLE
Add `legacy-syntax` and `syn-2` features

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build_and_test:
+    strategy:
+      matrix:
+        options:
+          ["--features=default", "--no-default-features --features=syn-2"]
 
     runs-on: ubuntu-latest
 
@@ -20,27 +24,27 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all --bins --examples --tests
+          args: ${{ matrix.options }} --all --bins --examples --tests
 
       - name: tests (async)
         uses: actions-rs/cargo@v1
         timeout-minutes: 40
         with:
           command: test
-          args: --all --no-fail-fast -- --nocapture
+          args: ${{ matrix.options }} --all --no-fail-fast -- --nocapture
 
       - name: check build (is_sync)
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features=is_sync --all --bins --examples --tests
+          args: ${{ matrix.options }} --features=is_sync --all --bins --examples --tests
 
       - name: tests (is_sync)
         uses: actions-rs/cargo@v1
         timeout-minutes: 40
         with:
           command: test
-          args: --features=is_sync --all --no-fail-fast -- --nocapture
+          args: ${{ matrix.options }} --features=is_sync --all --no-fail-fast -- --nocapture
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,16 @@ keywords = [ "maybe", "async", "futures", "macros", "proc_macro" ]
 proc-macro2 = "1.0"
 quote = "1.0"
 
-  [dependencies.syn]
+  [dependencies.syn-1]
+  package = "syn"
   version = "1.0"
   features = [ "visit-mut", "full" ]
+  optional = true
+
+  [dependencies.syn-2]
+  package = "syn"
+  version = "2.0"
+  optional = true
 
 [lib]
 proc-macro = true
@@ -40,5 +47,11 @@ async-trait = "0.1"
   features = [ "macros", "rt-multi-thread" ]
 
 [features]
-default = [ ]
-is_sync = [ ]
+default = ["legacy-syntax"]
+is_sync = []
+legacy-syntax = ["syn-1"]
+syn-1 = ["dep:syn-1"]
+syn-2 = ["dep:syn-2"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "doc_cfg"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    if cfg!(all(feature = "syn-1", feature = "syn-2")) {
+        panic!("Features `syn-1` and `syn-2` cannot both be enabled.");
+    }
+
+    if cfg!(not(any(feature = "syn-1", feature = "syn-2"))) {
+        panic!("At least one of `syn-1` and `syn-2` must be enabled.");
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "syn-1")]
+use syn_1 as syn;
+
+#[cfg(feature = "syn-2")]
+use syn_2 as syn;
+
 use proc_macro2::Span;
 use syn::{
     parse::{discouraged::Speculative, Parse, ParseStream, Result},

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -1,13 +1,19 @@
 use std::iter::FromIterator;
 
+#[cfg(feature = "syn-1")]
+use syn_1::{self as syn, GenericArgument::Binding as GenericArgumentBinding};
+
+#[cfg(feature = "syn-2")]
+use syn_2::{self as syn, GenericArgument::AssocType as GenericArgumentBinding};
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     parse_quote,
     punctuated::Punctuated,
     visit_mut::{self, visit_item_mut, visit_path_segment_mut, VisitMut},
-    Expr, ExprBlock, File, GenericArgument, GenericParam, Item, PathArguments, PathSegment, Type,
-    TypeParamBound, WherePredicate,
+    Expr, ExprBlock, File, GenericParam, Item, PathArguments, PathSegment, Type, TypeParamBound,
+    WherePredicate,
 };
 
 pub struct ReplaceGenericType<'a> {
@@ -187,7 +193,7 @@ fn search_trait_bound(
             // match Future<Output=Type>
             if let PathArguments::AngleBracketed(args) = &segment.arguments {
                 // binding: Output=Type
-                if let GenericArgument::Binding(binding) = &args.args[0] {
+                if let GenericArgumentBinding(binding) = &args.args[0] {
                     if let Type::Path(p) = &binding.ty {
                         inputs.push((generic_type_name.to_owned(), p.path.segments[0].clone()));
                     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,12 +4,16 @@ fn ui() {
     t.pass("tests/ui/01-maybe-async.rs");
     t.pass("tests/ui/02-must-be-async.rs");
     t.pass("tests/ui/03-must-be-sync.rs");
-    t.pass("tests/ui/04-unit-test-util.rs");
+    if cfg!(feature = "legacy-syntax") {
+        t.pass("tests/ui/04-unit-test-util.rs");
+    }
     t.pass("tests/ui/05-replace-future-generic-type-with-output.rs");
     t.pass("tests/ui/06-sync_impl_async_impl.rs");
 
-    t.compile_fail("tests/ui/test_fail/01-empty-test.rs");
-    t.compile_fail("tests/ui/test_fail/02-unknown-path.rs");
-    t.compile_fail("tests/ui/test_fail/03-async-gt2.rs");
-    t.compile_fail("tests/ui/test_fail/04-bad-sync-cond.rs");
+    if cfg!(feature = "legacy-syntax") {
+        t.compile_fail("tests/ui/test_fail/01-empty-test.rs");
+        t.compile_fail("tests/ui/test_fail/02-unknown-path.rs");
+        t.compile_fail("tests/ui/test_fail/03-async-gt2.rs");
+        t.compile_fail("tests/ui/test_fail/04-bad-sync-cond.rs");
+    }
 }

--- a/tests/unit-test-util.rs
+++ b/tests/unit-test-util.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "legacy-syntax")]
+
 use maybe_async::maybe_async;
 
 #[maybe_async]


### PR DESCRIPTION
This PR does essentially two things:
- Adds an enabled-by-default feature `legacy-syntax` and gates the `test` macro behind that feature
- Adds a `syn-2` feature to enabled use of `syn` version 2

[`gitoxide`](https://github.com/Byron/gitoxide) brings in two copies of `syn`, version 1 and version 2.  Relying on `maybe-async` is the reason it needs version 1.

`maybe-async` cannot be easily converted to use `syn` version 2. `maybe-async`'s `test` macro uses `async` as a nested attribute name.  However, Rust 2018 added `async` as a keyword, and [keywords cannot be used as attribute names](https://doc.rust-lang.org/beta/reference/keywords.html#strict-keywords). For this reason, `syn` [does not parse them](https://github.com/dtolnay/syn/issues/1458#issuecomment-1563001731). One could try to work around the `syn` limitation, but one could also make a case that `async` should be changed to something else.

Despite all this, `gitoxide` does not use the `test` macro.

So, with the features described above, `gitodixde` can use `maybe-async` with `default-features = false, features = ["syn-2"]` and not have to bring in syn version 1.

---

I have not discussed this with the `gitoxide` maintainers. If you prefer, I could first get confirmation from them that they like this plan.

Also, I realize this is out of the blue. Feel free to nit anything, or close this PR if you don't like the idea.