### PR TITLE
Support impl blocks for types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,11 +323,17 @@ fn convert_async(input: &mut Item, async_trait_mode: AsyncTraitMode) -> TokenStr
             AsyncTraitMode::NotSend => quote!(#[async_trait::async_trait(?Send)]#item),
             AsyncTraitMode::Off => quote!(#item),
         },
-        Item::Impl(item) => match async_trait_mode {
-            AsyncTraitMode::Send => quote!(#[async_trait::async_trait]#item),
-            AsyncTraitMode::NotSend => quote!(#[async_trait::async_trait(?Send)]#item),
-            AsyncTraitMode::Off => quote!(#item),
-        },
+        Item::Impl(item) => {
+            let async_trait_mode = item
+                .trait_
+                .as_ref()
+                .map_or(AsyncTraitMode::Off, |_| async_trait_mode);
+            match async_trait_mode {
+                AsyncTraitMode::Send => quote!(#[async_trait::async_trait]#item),
+                AsyncTraitMode::NotSend => quote!(#[async_trait::async_trait(?Send)]#item),
+                AsyncTraitMode::Off => quote!(#item),
+            }
+        }
         Item::Fn(item) => quote!(#item),
         Item::Static(item) => quote!(#item),
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -23,9 +23,6 @@ impl Parse for Item {
         let attrs = input.call(Attribute::parse_outer)?;
         let mut fork;
         let item = if let Ok(mut item) = fork!(fork = input).parse::<ItemImpl>() {
-            if item.trait_.is_none() {
-                return Err(Error::new(Span::call_site(), "expected a trait impl"));
-            }
             item.attrs = attrs;
             Item::Impl(item)
         } else if let Ok(mut item) = fork!(fork = input).parse::<ItemTrait>() {
@@ -38,10 +35,7 @@ impl Parse for Item {
             item.attrs = attrs;
             Item::Static(item)
         } else {
-            return Err(Error::new(
-                Span::call_site(),
-                "expected trait impl, trait or fn",
-            ));
+            return Err(Error::new(Span::call_site(), "expected impl, trait or fn"));
         };
         input.advance_to(&fork);
         Ok(item)

--- a/tests/ui/01-maybe-async.rs
+++ b/tests/ui/01-maybe-async.rs
@@ -61,6 +61,17 @@ unsafe fn unsafe_fn() {}
 struct Struct;
 
 #[maybe_async]
+impl Struct {
+    fn sync_fn_inherent() {}
+
+    async fn declare_async_inherent(&self) {}
+
+    async fn async_fn_inherent(&self) {
+        async { self.declare_async_inherent().await }.await
+    }
+}
+
+#[maybe_async]
 impl Trait for Struct {
     fn sync_fn() {}
 
@@ -85,6 +96,8 @@ impl AfitTrait for Struct {
 #[cfg(feature = "is_sync")]
 fn main() -> std::result::Result<(), ()> {
     let s = Struct;
+    s.declare_async_inherent();
+    s.async_fn_inherent();
     s.declare_async();
     s.async_fn();
     s.declare_async_afit();
@@ -98,6 +111,8 @@ fn main() -> std::result::Result<(), ()> {
 #[async_std::main]
 async fn main() {
     let s = Struct;
+    s.declare_async_inherent().await;
+    s.async_fn_inherent().await;
     s.declare_async().await;
     s.async_fn().await;
     s.declare_async_afit().await;

--- a/tests/ui/02-must-be-async.rs
+++ b/tests/ui/02-must-be-async.rs
@@ -73,6 +73,18 @@ struct Struct;
 
 #[cfg(not(feature = "is_sync"))]
 #[maybe_async::must_be_async]
+impl Struct {
+    fn sync_fn_inherent() {}
+
+    async fn declare_async_inherent(&self) {}
+
+    async fn async_fn_inherent(&self) {
+        async { self.declare_async_inherent().await }.await
+    }
+}
+
+#[cfg(not(feature = "is_sync"))]
+#[maybe_async::must_be_async]
 impl Trait for Struct {
     fn sync_fn() {}
 
@@ -111,6 +123,8 @@ fn main() {}
 #[async_std::main]
 async fn main() {
     let s = Struct;
+    s.declare_async_inherent().await;
+    s.async_fn_inherent().await;
     s.declare_async().await;
     s.async_fn().await;
     s.declare_async_afit().await;

--- a/tests/ui/03-must-be-sync.rs
+++ b/tests/ui/03-must-be-sync.rs
@@ -49,6 +49,18 @@ struct Struct;
 
 #[cfg(feature = "is_sync")]
 #[maybe_async::must_be_sync]
+impl Struct {
+    fn sync_fn_inherent() {}
+
+    async fn declare_async_inherent(&self) {}
+
+    async fn async_fn_inherent(&self) {
+        async { self.declare_async_inherent().await }.await
+    }
+}
+
+#[cfg(feature = "is_sync")]
+#[maybe_async::must_be_sync]
 impl Trait for Struct {
     fn sync_fn() {}
 
@@ -62,6 +74,8 @@ impl Trait for Struct {
 #[cfg(feature = "is_sync")]
 fn main() -> std::result::Result<(), ()> {
     let s = Struct;
+    s.declare_async_inherent();
+    s.async_fn_inherent();
     s.declare_async();
     s.async_fn();
     async_fn();


### PR DESCRIPTION
This adds support for `impl Type` blocks to `maybe_async`, `must_be_async` and `must_be_sync`.

The changes are minimal as this reuses the machinery already in place for `impl Trait for Type`.

The main motivation for this change is better interoperability with macros from other crates that apply to impl blocks and need functions to be resolved to async/sync before they run.

Resolves #18